### PR TITLE
2021 11 16 precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: 21.7b0
+    hooks:
+    -   id: black

--- a/README.md
+++ b/README.md
@@ -19,9 +19,13 @@
 
 Note: Set up a [python virtual environment](https://docs.python.org/3/tutorial/venv.html) before installing to make your life easier.
 
-```
+```bash
 git clone git@github.com:AndreasAlbert/vbfml.git
 python3 -m pip install -e vbfml
+
+# Install pre-commit hooks to automatically
+# format code when committing
+pre-commit install 
 ```
 
 ## Contributing

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ keras
 mplhep
 numpy
 pandas
+pre-commit
 pytest
 sklearn
 tabulate


### PR DESCRIPTION
@alpakpinar @abdelazizhussein I am adding precommit hooks here, see https://pre-commit.com/ for technical details.

When upgrading to this version, please make sure to reinstall vbfml to pick up the new dependency and then install the hook:
```
cd /path/to/vbfml/
python3 -m pip install -e .
pre-commit install
```

After this is done, the hooks defined in the yaml file will be executed every time one tries to `git commit`. In the current configuration, there is only one hook, which runs the black code formatter. Upon commit, it is run over the files in the commit. If they do not already conform to the code style, the commit is aborted. In this case, just add the file again to pick up the changes black made, and re-commit. We can modify and/or extend this behavior at will, so let me know if you have suggestions, concerns or questions.