### PR TITLE
Different feature scaling for different models

### DIFF
--- a/vbfml/config/convolutional_model.yml
+++ b/vbfml/config/convolutional_model.yml
@@ -1,11 +1,15 @@
 architecture: conv
 training_parameters:
   batch_size: 10
-  batch_buffer_size: 100
+  batch_buffer_size: 1000
+  scale_features: norm
+  shuffle: true
   train_size: 0.67
 validation_parameters:
-  batch_size: 100
+  batch_size: 1000
   batch_buffer_size: 10
+  scale_features: norm
+  shuffle: true
 weight_expression: Normalization
 features:
 - JetImage_pixels

--- a/vbfml/config/dense_model.yml
+++ b/vbfml/config/dense_model.yml
@@ -3,9 +3,13 @@ training_parameters:
   batch_size: 20
   batch_buffer_size: 1000000
   train_size: 0.5
+  scale_features: standard
+  shuffle: true
 validation_parameters:
   batch_size: 1000000
   batch_buffer_size: 10
+  scale_features: standard
+  shuffle: true
 weight_expression: weight_total*xs/sumw
 features:
 - mjj

--- a/vbfml/input/sequences.py
+++ b/vbfml/input/sequences.py
@@ -270,6 +270,11 @@ class MultiDatasetSequence(Sequence):
         if self.scale_features != "none":
             features = self.apply_feature_scaling(features)
 
+        # Double checking the feature range here
+        if self.scale_features == "norm":
+            valid = np.all(features >= 0) & np.all(features <= 1)
+            assert valid, "Features are not scaled correctly to [0,1] range, please check!"
+
         labels = to_categorical(
             row_vector(df["label"]),
             num_classes=len(self.dataset_labels()),

--- a/vbfml/input/sequences.py
+++ b/vbfml/input/sequences.py
@@ -272,7 +272,7 @@ class MultiDatasetSequence(Sequence):
 
         # Double checking the feature range here
         if self.scale_features == "norm":
-            valid = np.all(features >= 0) & np.all(features <= 1)
+            valid = np.all((features >= 0) & (features <= 1))
             assert valid, "Features are not scaled correctly to [0,1] range, please check!"
 
         labels = to_categorical(

--- a/vbfml/input/sequences.py
+++ b/vbfml/input/sequences.py
@@ -27,6 +27,24 @@ def row_vector(branch):
     return np.array(branch).reshape((len(branch), 1))
 
 
+class Normalizer:
+    def __init__(self) -> None:
+        pass
+
+    def fit(self, features: np.ndarray):
+        return self
+
+    def transform(self, features: np.ndarray, ceiling: float = 255.0):
+        """Simple normalizer for image data. Divides all values with 255
+        to get all values within [0,1] range.
+
+        Args:
+            features (np.ndarray): Image pixels.
+            ceiling (float, optional): The highest pixel value. Defaults to 255.
+        """
+        return features / ceiling
+
+
 class MultiDatasetSequence(Sequence):
     def __init__(
         self,
@@ -36,7 +54,7 @@ class MultiDatasetSequence(Sequence):
         batch_buffer_size=1,
         read_range=(0.0, 1.0),
         weight_expression=None,
-        scale_features=False,
+        scale_features="none",
     ) -> None:
         self.datasets = {}
         self.readers = {}
@@ -76,11 +94,11 @@ class MultiDatasetSequence(Sequence):
         self._batch_size = batch_size
 
     @property
-    def scale_features(self) -> bool:
+    def scale_features(self) -> str:
         return self._scale_features
 
     @scale_features.setter
-    def scale_features(self, scale_features: bool) -> None:
+    def scale_features(self, scale_features: str) -> None:
         if scale_features != self.scale_features:
             self.buffer.clear()
         self._scale_features = scale_features
@@ -118,7 +136,8 @@ class MultiDatasetSequence(Sequence):
         """
         Initialize the feature scaler object based on a feature tensor.
         """
-        self._feature_scaler = StandardScaler().fit(features)
+        scalers = {"standard": StandardScaler, "norm": Normalizer}
+        self._feature_scaler = scalers[self._scale_features]().fit(features)
 
     def _init_feature_scaler_from_multibatch(self, df: "pd.DataFrame") -> None:
         """
@@ -237,7 +256,7 @@ class MultiDatasetSequence(Sequence):
         Read batches from file and save them into the buffer for future use.
         """
         multibatch_df = self._read_multibatch(batch_start, batch_stop)
-        if self.scale_features and not self._feature_scaler:
+        if self.scale_features != "none" and not self._feature_scaler:
             self._init_feature_scaler_from_multibatch(multibatch_df)
         if self.shuffle:
             multibatch_df = multibatch_df.sample(frac=1, ignore_index=True)
@@ -248,7 +267,7 @@ class MultiDatasetSequence(Sequence):
 
         features = df.drop(columns=self._non_feature_columns()).to_numpy()
         features = features.astype(self._float_dtype)
-        if self.scale_features:
+        if self.scale_features != "none":
             features = self.apply_feature_scaling(features)
 
         labels = to_categorical(

--- a/vbfml/scripts/train.py
+++ b/vbfml/scripts/train.py
@@ -83,33 +83,36 @@ def setup(ctx, learning_rate: float, dropout: float, input_dir: str, model_confi
 
     features = mconfig.get("features")
 
+    training_params = mconfig.get("training_parameters")
+    validation_params = mconfig.get("validation_parameters")
+
     training_sequence = build_sequence(
         datasets=copy.deepcopy(datasets),
         features=features,
         weight_expression=mconfig.get("weight_expression"),
+        shuffle=training_params["shuffle"],
+        scale_features=training_params["scale_features"],
     )
     validation_sequence = build_sequence(
         datasets=copy.deepcopy(datasets),
         features=features,
         weight_expression=mconfig.get("weight_expression"),
+        shuffle=validation_params["shuffle"],
+        scale_features=validation_params["scale_features"],
     )
     normalize_classes(training_sequence)
     normalize_classes(validation_sequence)
 
     # Training sequence
-    training_params = mconfig.get("training_parameters")
     train_size = training_params["train_size"]
 
     training_sequence.read_range = (0.0, train_size)
-    training_sequence.scale_features = True
     training_sequence.batch_size = training_params["batch_size"]
     training_sequence.batch_buffer_size = training_params["batch_buffer_size"]
     training_sequence[0]
 
     # Validation sequence
-    validation_params = mconfig.get("validation_parameters")
     validation_sequence.read_range = (train_size, 1.0)
-    validation_sequence.scale_features = True
     validation_sequence._feature_scaler = copy.deepcopy(
         training_sequence._feature_scaler
     )

--- a/vbfml/tests/test_postprocessing.py
+++ b/vbfml/tests/test_postprocessing.py
@@ -78,7 +78,7 @@ class TestTrainingAnalysisAndPlot(TestCase):
 
         datasets = load_datasets_bucoffea(self.wdir)
         sequence = build_sequence(datasets, features=self.features)
-        sequence.scale_features = True
+        sequence.scale_features = "standard"
         self.training_sequence = sequence
         self.validation_sequence = copy.deepcopy(sequence)
 

--- a/vbfml/training/analysis.py
+++ b/vbfml/training/analysis.py
@@ -104,7 +104,7 @@ class TrainingAnalyzer:
         histograms = {}
         for sequence_type in ["training", "validation"]:
             sequence = self.loader.get_sequence(sequence_type)
-            sequence.scale_features = False
+            sequence.scale_features = "none"
             sequence.batch_size = int(1e6)
             sequence.batch_buffer_size = 10
             (

--- a/vbfml/training/input.py
+++ b/vbfml/training/input.py
@@ -11,6 +11,8 @@ def build_sequence(
     features: "list[str]",
     weight_expression: str = "weight_total*xs/sumw",
     absolute_weight: bool = False,
+    shuffle: bool = True,
+    scale_features: str = "standard",
 ) -> MultiDatasetSequence:
     """Shortcut to set up a MultiDatasetSequence"""
 
@@ -20,9 +22,10 @@ def build_sequence(
     sequence = MultiDatasetSequence(
         batch_size=50,
         branches=features,
-        shuffle=True,
+        shuffle=shuffle,
         batch_buffer_size=int(1e5),
         weight_expression=weight_expression,
+        scale_features=scale_features,
     )
 
     for dataset in datasets:


### PR DESCRIPTION
Hey @AndreasAlbert, @abdelazizhussein, here is an implementation for a possible resolution of #15. I updated the `scale_features` attribute of `MultiDatasetSequence` class so that we can use different scalers for different models. I also updated + included some tests accordingly.

Let me know if you have any comments or questions, thanks!   